### PR TITLE
Add RoutingOptions to payment requests

### DIFF
--- a/adapter/model.go
+++ b/adapter/model.go
@@ -60,6 +60,7 @@ type CardVerifyStatus string
 type CardBrand string
 type ClientType string
 type MasterpassValidationType string
+type OrderingRule string
 
 const (
     ApiKeyHeaderName        = "x-api-key"
@@ -671,6 +672,17 @@ const (
     MasterpassValidationType_THREE_DS MasterpassValidationType = "THREE_DS"
 )
 
+const (
+    OrderingRule_ON_US               OrderingRule = "ON_US"
+    OrderingRule_LOW_COMMISSION_RATE OrderingRule = "LOW_COMMISSION_RATE"
+    OrderingRule_IN_ORDER            OrderingRule = "IN_ORDER"
+)
+
+type RoutingOptions struct {
+    OrderingRule *OrderingRule `json:"orderingRule,omitempty"`
+    PosAliases   []string      `json:"posAliases,omitempty"`
+}
+
 // requests
 type CreatePaymentRequest struct {
     Price            float64                `json:"price,omitempty"`
@@ -688,6 +700,7 @@ type CreatePaymentRequest struct {
     BuyerMemberId    int64                  `json:"buyerMemberId,omitempty"`
     BankOrderId      string                 `json:"bankOrderId,omitempty"`
     Card             *Card                  `json:"card,omitempty"`
+    RoutingOptions   *RoutingOptions        `json:"routingOptions,omitempty"`
     FraudParams      *FraudCheckParameters  `json:"fraudParams,omitempty"`
     Items            []PaymentItem          `json:"items"`
     AdditionalParams map[string]interface{} `json:"additionalParams,omitempty"`
@@ -725,6 +738,7 @@ type Init3DSPaymentRequest struct {
     BuyerMemberId    int64                  `json:"buyerMemberId,omitempty"`
     BankOrderId      string                 `json:"bankOrderId,omitempty"`
     Card             *Card                  `json:"card,omitempty"`
+    RoutingOptions   *RoutingOptions        `json:"routingOptions,omitempty"`
     CallbackUrl      string                 `json:"callbackUrl,omitempty"`
     Items            []PaymentItem          `json:"items"`
     AdditionalParams map[string]interface{} `json:"additionalParams"`
@@ -763,6 +777,7 @@ type InitCheckoutPaymentRequest struct {
     Ttl                         int64                          `json:"ttl,omitempty"`
     CustomInstallments          []CustomInstallment            `json:"customInstallments,omitempty"`
     Items                       []PaymentItem                  `json:"items"`
+    RoutingOptions              *RoutingOptions                `json:"routingOptions,omitempty"`
     FraudParams                 *FraudCheckParameters          `json:"fraudParams,omitempty"`
     AdditionalParams            map[string]interface{}         `json:"additionalParams,omitempty"`
     CardBrandInstallments       map[string][]CustomInstallment `json:"cardBrandInstallments,omitempty"`
@@ -854,14 +869,15 @@ type PostAuthPaymentRequest struct {
 }
 
 type DepositPaymentRequest struct {
-    BuyerMemberId  int64    `json:"buyerMemberId,omitempty"`
-    Price          float64  `json:"price,omitempty"`
-    Currency       Currency `json:"currency,omitempty"`
-    ConversationId string   `json:"conversationId,omitempty"`
-    CallbackUrl    string   `json:"callbackUrl,omitempty"`
-    PosAlias       string   `json:"posAlias,omitempty"`
-    ClientIp       string   `json:"clientIp,omitempty"`
-    Card           Card     `json:"card"`
+    BuyerMemberId  int64            `json:"buyerMemberId,omitempty"`
+    Price          float64          `json:"price,omitempty"`
+    Currency       Currency         `json:"currency,omitempty"`
+    ConversationId string           `json:"conversationId,omitempty"`
+    CallbackUrl    string           `json:"callbackUrl,omitempty"`
+    PosAlias       string           `json:"posAlias,omitempty"`
+    ClientIp       string           `json:"clientIp,omitempty"`
+    Card           Card             `json:"card"`
+    RoutingOptions *RoutingOptions  `json:"routingOptions,omitempty"`
 }
 
 type CreateFundTransferDepositPaymentRequest struct {


### PR DESCRIPTION
## Summary
Add RoutingOptions struct to payment requests to allow clients to specify routing preferences.

## Changes
- Add `RoutingOptions` struct with `OrderingRule` type (ON_US, LOW_COMMISSION_RATE, IN_ORDER) and `PosAliases` field
- Add `RoutingOptions` field to:
  - `CreatePaymentRequest`
  - `Init3DSPaymentRequest`
  - `DepositPaymentRequest`
  - `InitCheckoutPaymentRequest`

## Technical Details
- `OrderingRule` type constants: `OrderingRule_ON_US`, `OrderingRule_LOW_COMMISSION_RATE`, `OrderingRule_IN_ORDER`
- `PosAliases`: Optional slice of POS aliases for routing configuration
- All fields use `omitempty` JSON tag to maintain backward compatibility

## Test Plan
- [ ] Verify compilation
- [ ] Test payment request creation with RoutingOptions
- [ ] Test backward compatibility (requests without RoutingOptions)
- [ ] Verify JSON serialization/deserialization