### PR TITLE
Add TURKONAY pos integrator

### DIFF
--- a/adapter/model.go
+++ b/adapter/model.go
@@ -546,6 +546,7 @@ const (
     PosIntegrator_TAP               PosIntegrator = "TAP"
     PosIntegrator_RUBIK             PosIntegrator = "RUBIK"
     PosIntegrator_BIN_PAY           PosIntegrator = "BIN_PAY"
+    PosIntegrator_TURKONAY          PosIntegrator = "TURKONAY"
 )
 
 const (


### PR DESCRIPTION
## Summary
- add TURKONAY to PosIntegrator

## Verification
- build/compile checks passed
- verified a local non-3DS TurkOnay payment via the client against http://localhost:8000 using merchant 2 and pos alias 915-turkonay-125